### PR TITLE
fix: make keyword matching case-insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Labeling
-        uses: hopeman15/labelicious@0.3.0
+        uses: hopeman15/labelicious@0.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/src/label.sh
+++ b/src/label.sh
@@ -9,7 +9,7 @@ REPO="${REPO:?REPO is not set}"
 PR_TITLE=$(gh pr view "$PR_NUMBER" -R "$REPO" --json title -q '.title')
 
 "${GITHUB_ACTION_PATH}/src/parse_labels.sh" | while IFS=',' read -r keyword label; do
-  if [[ "$PR_TITLE" == *"$keyword"* ]]; then
+  if [[ "${PR_TITLE,,}" == *"${keyword,,}"* ]]; then
     echo "Adding label: $label for keyword: $keyword"
     gh pr edit "$PR_NUMBER" --add-label "$label" -R "$REPO"
   fi


### PR DESCRIPTION
## Description

Keyword matching for PR title labels was case-sensitive, so a keyword like `feature` would not match a PR title containing `Feature` or `FEATURE`. This fix lowercases both the PR title and keyword before comparison using bash parameter expansion (`${var,,}`), making matching case-insensitive.

## How to test/reproduce

1. Configure a keyword like `feature` with a corresponding label
2. Create a PR with a title containing `Feature` (capitalized)
3. The label should now be applied correctly

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [x] Appropriate labels have been applied
- [x] Update [README](../README.md) (where applicable)